### PR TITLE
HYDRAN-2647 EmailSender – support multiple recipients (To + CC) in a single email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-email-sender</artifactId>
-	<version>2.0</version>
+	<version>2.1</version>
 	<name>api-service-email-sender</name>
 	<properties>
 		<jilt.version>1.9.1</jilt.version>

--- a/src/integration-test/java/apptest/EmailIT.java
+++ b/src/integration-test/java/apptest/EmailIT.java
@@ -4,7 +4,9 @@ import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -22,6 +24,7 @@ import se.sundsvall.emailsender.Application;
 
 @Testcontainers
 @ExtendWith(ResourceLoaderExtension.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @WireMockAppTestSuite(files = "classpath:/EmailIT/", classes = Application.class)
 class EmailIT extends AbstractAppTest {
 
@@ -74,5 +77,31 @@ class EmailIT extends AbstractAppTest {
 			.jsonPath("$.messages[0].ReplyTo[0].Name").isEmpty()
 			.jsonPath("$.messages[0].ReplyTo[0].Address").isEqualTo(jsonPath.read("$.sender.replyTo"))
 			.jsonPath("$.messages[0].Attachments").isEqualTo(jsonPath.read("$.attachments.length()"));
+	}
+
+	@Test
+	void test2_successfulRequestWithRecipientsAndCc(@Load("/EmailIT/__files/test2_successfulRequestWithRecipientsAndCc/request.json") final String request) {
+		setupCall()
+			.withServicePath(SERVICE_PATH)
+			.withHttpMethod(POST)
+			.withRequest(REQUEST_FILE)
+			.withExpectedResponseStatus(OK)
+			.sendRequestAndVerifyResponse();
+
+		// Verify what was actually sent
+		var jsonPath = JsonPath.parse(request);
+
+		// Mailpit returns messages newest-first and its state is shared across tests, so assert on the newest ([0])
+		webTestClient.get()
+			.uri("/messages")
+			.exchange()
+			.expectBody()
+			.jsonPath("$.messages[0].Subject").isEqualTo(jsonPath.read("$.subject"))
+			.jsonPath("$.messages[0].To.length()").isEqualTo(2)
+			.jsonPath("$.messages[0].To[0].Address").isEqualTo(jsonPath.read("$.recipients[0]"))
+			.jsonPath("$.messages[0].To[1].Address").isEqualTo(jsonPath.read("$.recipients[1]"))
+			.jsonPath("$.messages[0].Cc.length()").isEqualTo(2)
+			.jsonPath("$.messages[0].Cc[0].Address").isEqualTo(jsonPath.read("$.cc[0]"))
+			.jsonPath("$.messages[0].Cc[1].Address").isEqualTo(jsonPath.read("$.cc[1]"));
 	}
 }

--- a/src/integration-test/resources/EmailIT/__files/test2_successfulRequestWithRecipientsAndCc/request.json
+++ b/src/integration-test/resources/EmailIT/__files/test2_successfulRequestWithRecipientsAndCc/request.json
@@ -1,0 +1,30 @@
+{
+	"headers": {
+		"Message-ID": [
+			"<0d151193@113c2234d334>"
+		]
+	},
+	"recipients": [
+		"recipient1@somehost.com",
+		"recipient2@somehost.com"
+	],
+	"cc": [
+		"cc1@somehost.com",
+		"cc2@somehost.com"
+	],
+	"attachments": [
+		{
+			"name": "myattachment.txt",
+			"contentType": "text/plain",
+			"content": "dGhpcyBpcyBhbiBhdHRhY2htZW50"
+		}
+	],
+	"sender": {
+		"address": "customerservice@somedummyhost.com",
+		"name": "Customer Service",
+		"replyTo": "noreply@somedummyhost.com"
+	},
+	"subject": "Order confirmation",
+	"htmlMessage": "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=",
+	"message": "Lorem ipsum dolor sit amet"
+}

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "2.0"
+  version: "2.1"
 servers:
 - url: http://localhost:8080
   description: Generated server url
@@ -161,10 +161,26 @@ components:
         emailAddress:
           type: string
           format: email
-          description: Recipient e-mail address
+          description: Recipient e-mail address. Deprecated, use 'recipients' instead
+          deprecated: true
           examples:
           - recipient@recipient.se
-          minLength: 1
+        recipients:
+          type: array
+          items:
+            type: string
+            format: email
+            description: Recipient (To) e-mail address
+            examples:
+            - recipient@recipient.se
+        cc:
+          type: array
+          items:
+            type: string
+            format: email
+            description: Carbon-copy (CC) e-mail address
+            examples:
+            - cc-recipient@recipient.se
         subject:
           type: string
           description: E-mail subject
@@ -189,7 +205,6 @@ components:
               type: string
           description: Headers
       required:
-      - emailAddress
       - sender
       - subject
     Sender:

--- a/src/main/java/se/sundsvall/emailsender/api/model/SendEmailRequest.java
+++ b/src/main/java/se/sundsvall/emailsender/api/model/SendEmailRequest.java
@@ -1,22 +1,32 @@
 package se.sundsvall.emailsender.api.model;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.jilt.Builder;
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
+import se.sundsvall.emailsender.api.validation.ValidEmailRecipients;
 import se.sundsvall.emailsender.api.validation.ValidHeaders;
 
+@ValidEmailRecipients
 @Builder(setterPrefix = "with", factoryMethod = "create", toBuilder = "from")
 @Schema(description = "The request class for sending an e-mail")
 public record SendEmailRequest(
 
-	@NotBlank @Email @Schema(description = "Recipient e-mail address", examples = "recipient@recipient.se") String emailAddress,
+	@Deprecated(forRemoval = true) @Email @Schema(description = "Recipient e-mail address. Deprecated, use 'recipients' instead", examples = "recipient@recipient.se", deprecated = true) String emailAddress,
+
+	@ArraySchema(schema = @Schema(description = "Recipient (To) e-mail address", format = "email", examples = "recipient@recipient.se")) List<@Email String> recipients,
+
+	@ArraySchema(schema = @Schema(description = "Carbon-copy (CC) e-mail address", format = "email", examples = "cc-recipient@recipient.se")) List<@Email String> cc,
 
 	@NotBlank @Schema(description = "E-mail subject") String subject,
 
@@ -29,6 +39,34 @@ public record SendEmailRequest(
 	List<@Valid Attachment> attachments,
 
 	@ValidHeaders @Schema(description = "Headers") Map<@NotBlank String, @NotEmpty List<String>> headers) {
+
+	/**
+	 * Merges the deprecated single {@code emailAddress} with the {@code recipients} list into the effective set of TO
+	 * recipients, preserving order and removing blanks and duplicates.
+	 *
+	 * @return the distinct, non-blank list of TO recipients
+	 */
+	public List<String> allRecipients() {
+		final var result = new LinkedHashSet<String>();
+		Optional.ofNullable(emailAddress)
+			.filter(StringUtils::isNotBlank)
+			.ifPresent(result::add);
+		Optional.ofNullable(recipients).orElse(List.of()).stream()
+			.filter(StringUtils::isNotBlank)
+			.forEach(result::add);
+		return List.copyOf(result);
+	}
+
+	/**
+	 * @return the distinct, non-blank list of CC recipients
+	 */
+	public List<String> allCc() {
+		final var result = new LinkedHashSet<String>();
+		Optional.ofNullable(cc).orElse(List.of()).stream()
+			.filter(StringUtils::isNotBlank)
+			.forEach(result::add);
+		return List.copyOf(result);
+	}
 
 	@Builder(setterPrefix = "with", factoryMethod = "create", toBuilder = "from")
 	@Schema(description = "Attachment")

--- a/src/main/java/se/sundsvall/emailsender/api/validation/ValidEmailRecipients.java
+++ b/src/main/java/se/sundsvall/emailsender/api/validation/ValidEmailRecipients.java
@@ -1,0 +1,25 @@
+package se.sundsvall.emailsender.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import se.sundsvall.emailsender.api.validation.impl.ValidEmailRecipientsConstraintValidator;
+
+@Documented
+@Target({
+	ElementType.TYPE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidEmailRecipientsConstraintValidator.class)
+public @interface ValidEmailRecipients {
+	String message() default "at least one recipient must be provided in 'emailAddress' or 'recipients'";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/se/sundsvall/emailsender/api/validation/impl/ValidEmailRecipientsConstraintValidator.java
+++ b/src/main/java/se/sundsvall/emailsender/api/validation/impl/ValidEmailRecipientsConstraintValidator.java
@@ -1,0 +1,17 @@
+package se.sundsvall.emailsender.api.validation.impl;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import se.sundsvall.emailsender.api.model.SendEmailRequest;
+import se.sundsvall.emailsender.api.validation.ValidEmailRecipients;
+
+public class ValidEmailRecipientsConstraintValidator implements ConstraintValidator<ValidEmailRecipients, SendEmailRequest> {
+
+	@Override
+	public boolean isValid(final SendEmailRequest request, final ConstraintValidatorContext context) {
+		if (request == null) {
+			return true;
+		}
+		return !request.allRecipients().isEmpty();
+	}
+}

--- a/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
+++ b/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
@@ -40,7 +40,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 
 	@Override
 	public void sendEmail(final SendEmailRequest request) {
-		LOGGER.info("Sending email to: {}", request.emailAddress());
+		LOGGER.info("Sending email to: {}", request.allRecipients());
 		try {
 			final var sender = request.sender();
 
@@ -50,8 +50,18 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 			message.setSubject(request.subject());
 			message.setBody(createItemBody(request));
 
-			// Recipient
-			message.setToRecipients(List.of(createRecipient(request.emailAddress())));
+			// Recipients (TO)
+			message.setToRecipients(request.allRecipients().stream()
+				.map(this::createRecipient)
+				.toList());
+
+			// Carbon-copy recipients (CC)
+			final var ccRecipients = request.allCc();
+			if (!ccRecipients.isEmpty()) {
+				message.setCcRecipients(ccRecipients.stream()
+					.map(this::createRecipient)
+					.toList());
+			}
 
 			// Reply-to
 			final var replyTo = ofNullable(sender.replyTo())
@@ -86,7 +96,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 				.sendMail()
 				.post(requestBody);
 		} catch (final Exception e) {
-			LOGGER.error("Error sending email to: {}", request.emailAddress(), e);
+			LOGGER.error("Error sending email to: {}", request.allRecipients(), e);
 			throw Problem.builder()
 				.withStatus(INTERNAL_SERVER_ERROR)
 				.withDetail("Unable to send e-mail")

--- a/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
+++ b/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
@@ -40,7 +40,8 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 
 	@Override
 	public void sendEmail(final SendEmailRequest request) {
-		LOGGER.info("Sending email to {} recipient(s)", request.allRecipients().size());
+		final var recipients = request.allRecipients();
+		LOGGER.info("Sending email to {} recipient(s)", recipients.size());
 		try {
 			final var sender = request.sender();
 
@@ -51,7 +52,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 			message.setBody(createItemBody(request));
 
 			// Recipients (TO)
-			message.setToRecipients(request.allRecipients().stream()
+			message.setToRecipients(recipients.stream()
 				.map(this::createRecipient)
 				.toList());
 
@@ -96,7 +97,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 				.sendMail()
 				.post(requestBody);
 		} catch (final Exception e) {
-			LOGGER.error("Error sending email to {} recipient(s)", request.allRecipients().size(), e);
+			LOGGER.error("Error sending email to {} recipient(s)", recipients.size(), e);
 			throw Problem.builder()
 				.withStatus(INTERNAL_SERVER_ERROR)
 				.withDetail("Unable to send e-mail")

--- a/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
+++ b/src/main/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSender.java
@@ -40,7 +40,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 
 	@Override
 	public void sendEmail(final SendEmailRequest request) {
-		LOGGER.info("Sending email to: {}", request.allRecipients());
+		LOGGER.info("Sending email to {} recipient(s)", request.allRecipients().size());
 		try {
 			final var sender = request.sender();
 
@@ -96,7 +96,7 @@ public class MicrosoftGraphMailSender extends AbstractMailSender {
 				.sendMail()
 				.post(requestBody);
 		} catch (final Exception e) {
-			LOGGER.error("Error sending email to: {}", request.allRecipients(), e);
+			LOGGER.error("Error sending email to {} recipient(s)", request.allRecipients().size(), e);
 			throw Problem.builder()
 				.withStatus(INTERNAL_SERVER_ERROR)
 				.withDetail("Unable to send e-mail")

--- a/src/main/java/se/sundsvall/emailsender/service/SmtpMailSender.java
+++ b/src/main/java/se/sundsvall/emailsender/service/SmtpMailSender.java
@@ -49,7 +49,7 @@ public class SmtpMailSender extends AbstractMailSender {
 
 			javaMailSender.send(mimeMessage);
 		} catch (MessagingException e) {
-			LOGGER.error("Error while sending email to: {}", request.emailAddress(), e);
+			LOGGER.error("Error while sending email to: {}", request.allRecipients(), e);
 			throw Problem.builder()
 				.withStatus(INTERNAL_SERVER_ERROR)
 				.withDetail("Unable to send e-mail")
@@ -71,8 +71,14 @@ public class SmtpMailSender extends AbstractMailSender {
 			.orElseGet(sender::address);
 		message.setReplyTo(InternetAddress.parse(replyTo));
 
-		// Handle recipient
-		message.setRecipients(Message.RecipientType.TO, request.emailAddress());
+		// Handle recipients (TO)
+		message.setRecipients(Message.RecipientType.TO, toInternetAddresses(request.allRecipients()));
+
+		// Handle carbon-copy recipients (CC)
+		var ccRecipients = request.allCc();
+		if (!ccRecipients.isEmpty()) {
+			message.setRecipients(Message.RecipientType.CC, toInternetAddresses(ccRecipients));
+		}
 
 		// Handle subject
 		message.setSubject(request.subject(), UTF_8.name());
@@ -87,6 +93,10 @@ public class SmtpMailSender extends AbstractMailSender {
 				formatHeader(header.getValue())));
 
 		return message;
+	}
+
+	InternetAddress[] toInternetAddresses(final List<String> addresses) throws MessagingException {
+		return InternetAddress.parse(String.join(",", addresses));
 	}
 
 	String encode(final String s) throws MessagingException {

--- a/src/main/java/se/sundsvall/emailsender/service/SmtpMailSender.java
+++ b/src/main/java/se/sundsvall/emailsender/service/SmtpMailSender.java
@@ -49,7 +49,7 @@ public class SmtpMailSender extends AbstractMailSender {
 
 			javaMailSender.send(mimeMessage);
 		} catch (MessagingException e) {
-			LOGGER.error("Error while sending email to: {}", request.allRecipients(), e);
+			LOGGER.error("Error while sending email to {} recipient(s)", request.allRecipients().size(), e);
 			throw Problem.builder()
 				.withStatus(INTERNAL_SERVER_ERROR)
 				.withDetail("Unable to send e-mail")

--- a/src/test/java/se/sundsvall/emailsender/TestDataFactory.java
+++ b/src/test/java/se/sundsvall/emailsender/TestDataFactory.java
@@ -45,6 +45,14 @@ public final class TestDataFactory {
 			.build();
 	}
 
+	public static SendEmailRequest createValidSendEmailRequestWithRecipientsAndCc() {
+		return SendEmailRequestBuilder.from(createValidSendEmailRequest())
+			.withEmailAddress(null)
+			.withRecipients(List.of("receiver1@receiver.com", "receiver2@receiver.com"))
+			.withCc(List.of("cc1@receiver.com", "cc2@receiver.com"))
+			.build();
+	}
+
 	public static SendEmailRequest.Sender createValidSender() {
 		return SenderBuilder.create()
 			.withName("Sundsvalls Kommun")

--- a/src/test/java/se/sundsvall/emailsender/api/EmailResourceFailureTests.java
+++ b/src/test/java/se/sundsvall/emailsender/api/EmailResourceFailureTests.java
@@ -102,6 +102,32 @@ class EmailResourceFailureTests {
 	}
 
 	@Test
+	void sendMailWithNoRecipients() {
+		var request = SendEmailRequestBuilder.from(createValidSendEmailRequest())
+			.withEmailAddress(null)
+			.withRecipients(null)
+			.build();
+
+		var response = webTestClient.post()
+			.uri(builder -> builder.path(PATH).build())
+			.bodyValue(request)
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response).isNotNull().satisfies(r -> {
+			assertThat(r.getTitle()).isEqualTo("Constraint Violation");
+			assertThat(r.getStatus()).isEqualTo(BAD_REQUEST);
+			assertThat(r.getViolations()).extracting(Violation::message)
+				.contains("at least one recipient must be provided in 'emailAddress' or 'recipients'");
+		});
+
+		verifyNoInteractions(mockEmailService);
+	}
+
+	@Test
 	void sendMailWithFaultyMunicipalityId() {
 		var request = createValidSendEmailRequest();
 

--- a/src/test/java/se/sundsvall/emailsender/api/model/SendEmailRequestValidationTests.java
+++ b/src/test/java/se/sundsvall/emailsender/api/model/SendEmailRequestValidationTests.java
@@ -66,10 +66,17 @@ class SendEmailRequestValidationTests {
 		var validEmailRequest = createValidSendEmailRequest();
 
 		return Stream.of(
-			// Validate recipient email address.
-			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withEmailAddress(null).build(), "emailAddress", "must not be blank"),
-			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withEmailAddress("").build(), "emailAddress", "must not be blank"),
+			// Validate deprecated recipient email address format.
 			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withEmailAddress("kalle").build(), "emailAddress", "must be a well-formed email address"),
+
+			// Validate that at least one recipient is provided (neither emailAddress nor recipients).
+			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withEmailAddress(null).withRecipients(null).build(), "", "at least one recipient must be provided in 'emailAddress' or 'recipients'"),
+
+			// Validate recipients (To) list element email address format.
+			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withEmailAddress(null).withRecipients(List.of("kalle")).build(), "recipients[0].<list element>", "must be a well-formed email address"),
+
+			// Validate cc list element email address format.
+			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest).withCc(List.of("kalle")).build(), "cc[0].<list element>", "must be a well-formed email address"),
 
 			// Validate sender email address.
 			Arguments.of(SendEmailRequestBuilder.from(validEmailRequest)

--- a/src/test/java/se/sundsvall/emailsender/api/validation/ValidEmailRecipientsConstraintValidatorTests.java
+++ b/src/test/java/se/sundsvall/emailsender/api/validation/ValidEmailRecipientsConstraintValidatorTests.java
@@ -1,0 +1,47 @@
+package se.sundsvall.emailsender.api.validation;
+
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import se.sundsvall.emailsender.api.model.SendEmailRequestBuilder;
+import se.sundsvall.emailsender.api.validation.impl.ValidEmailRecipientsConstraintValidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static se.sundsvall.emailsender.TestDataFactory.createValidSendEmailRequest;
+
+class ValidEmailRecipientsConstraintValidatorTests {
+
+	private final ValidEmailRecipientsConstraintValidator validator = new ValidEmailRecipientsConstraintValidator();
+	private final ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+	@Test
+	void nullRequestIsValid() {
+		assertThat(validator.isValid(null, context)).isTrue();
+	}
+
+	@Test
+	void requestWithEmailAddressIsValid() {
+		assertThat(validator.isValid(createValidSendEmailRequest(), context)).isTrue();
+	}
+
+	@Test
+	void requestWithRecipientsIsValid() {
+		var request = SendEmailRequestBuilder.from(createValidSendEmailRequest())
+			.withEmailAddress(null)
+			.withRecipients(List.of("recipient@recipient.se"))
+			.build();
+
+		assertThat(validator.isValid(request, context)).isTrue();
+	}
+
+	@Test
+	void requestWithoutAnyRecipientIsInvalid() {
+		var request = SendEmailRequestBuilder.from(createValidSendEmailRequest())
+			.withEmailAddress(null)
+			.withRecipients(null)
+			.build();
+
+		assertThat(validator.isValid(request, context)).isFalse();
+	}
+}

--- a/src/test/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSenderTests.java
+++ b/src/test/java/se/sundsvall/emailsender/service/MicrosoftGraphMailSenderTests.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.emailsender.TestDataFactory.createValidSendEmailRequest;
+import static se.sundsvall.emailsender.TestDataFactory.createValidSendEmailRequestWithRecipientsAndCc;
 
 @ExtendWith(MockitoExtension.class)
 class MicrosoftGraphMailSenderTests {
@@ -92,6 +93,29 @@ class MicrosoftGraphMailSenderTests {
 		verify(mockSendMailRequestBuilder).post(mockSendMailPostRequestBody);
 
 		verifyNoMoreInteractions(microsoftGraphMailSenderSpy, mockMessage, mockSendMailPostRequestBody, mockGraphServiceClient, mockUsersRequestBuilder, mockUserItemRequestBuilder, mockSendMailRequestBuilder);
+	}
+
+	@Test
+	void sendEmailWithRecipientsAndCc() {
+		final var request = createValidSendEmailRequestWithRecipientsAndCc();
+
+		final var microsoftGraphMailSenderSpy = spy(microsoftGraphMailSender);
+		final var mockMessage = mock(Message.class);
+		when(microsoftGraphMailSenderSpy.createMessage()).thenReturn(mockMessage);
+		final var mockSendMailPostRequestBody = mock(SendMailPostRequestBody.class);
+		when(microsoftGraphMailSenderSpy.createSendMailPostRequestBody()).thenReturn(mockSendMailPostRequestBody);
+
+		final var mockUsersRequestBuilder = mock(UsersRequestBuilder.class);
+		when(mockGraphServiceClient.users()).thenReturn(mockUsersRequestBuilder);
+		final var mockUserItemRequestBuilder = mock(UserItemRequestBuilder.class);
+		when(mockUsersRequestBuilder.byUserId(request.sender().address())).thenReturn(mockUserItemRequestBuilder);
+		final var mockSendMailRequestBuilder = mock(SendMailRequestBuilder.class);
+		when(mockUserItemRequestBuilder.sendMail()).thenReturn(mockSendMailRequestBuilder);
+
+		microsoftGraphMailSenderSpy.sendEmail(request);
+
+		verify(mockMessage).setToRecipients(anyList());
+		verify(mockMessage).setCcRecipients(anyList());
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/emailsender/service/SmtpMailSenderTests.java
+++ b/src/test/java/se/sundsvall/emailsender/service/SmtpMailSenderTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.emailsender.TestDataFactory.createValidSendEmailRequest;
+import static se.sundsvall.emailsender.TestDataFactory.createValidSendEmailRequestWithRecipientsAndCc;
 
 @ExtendWith(MockitoExtension.class)
 class SmtpMailSenderTests {
@@ -49,7 +50,7 @@ class SmtpMailSenderTests {
 		verifyNoMoreInteractions(mockJavaMailSender);
 		verify(mockMimeMessage).setFrom(any(String.class));
 		verify(mockMimeMessage).setReplyTo(any(Address[].class));
-		verify(mockMimeMessage).setRecipients(eq(Message.RecipientType.TO), any(String.class));
+		verify(mockMimeMessage).setRecipients(eq(Message.RecipientType.TO), any(Address[].class));
 		verify(mockMimeMessage).setSubject(any(String.class), any(String.class));
 		verify(mockMimeMessage).setContent(any(Multipart.class));
 		verify(mockMimeMessage).addHeader("Message-ID", "<318d3a5c-cd45-45ef-94a0-0e3a88e47bf6@sundsvall.se>");
@@ -57,6 +58,19 @@ class SmtpMailSenderTests {
 		verify(mockMimeMessage).addHeader("In-Reply-To", "<5e0b2ce9-9b0c-4f8b-aa62-ebac666c5b64@sundsvall.se>");
 		verify(mockMimeMessage).addHeader("Auto-Submitted", "auto-generated");
 		verifyNoMoreInteractions(mockMimeMessage);
+	}
+
+	@Test
+	void sendEmail_withRecipientsAndCc() throws MessagingException {
+		var request = createValidSendEmailRequestWithRecipientsAndCc();
+
+		when(mockJavaMailSender.createMimeMessage()).thenReturn(mockMimeMessage);
+
+		smtpMailSender.sendEmail(request);
+
+		verify(mockJavaMailSender).send(mockMimeMessage);
+		verify(mockMimeMessage).setRecipients(eq(Message.RecipientType.TO), any(Address[].class));
+		verify(mockMimeMessage).setRecipients(eq(Message.RecipientType.CC), any(Address[].class));
 	}
 
 	@Test


### PR DESCRIPTION
## HYDRAN-2647

Extends EmailSender so a single send can go to a **list of recipients** (To) plus **CC**, instead of only one recipient.

### Changes
- `SendEmailRequest`: new `recipients` (To list) + `cc`; keep `emailAddress` as `@Deprecated` (backward-compatible) → **minor bump 2.0 → 2.1**.
- New class-level validator `@ValidEmailRecipients`: at least one recipient must be provided in `emailAddress` or `recipients`.
- SMTP (`SmtpMailSender`) and Microsoft Graph (`MicrosoftGraphMailSender`) senders now set multiple To addresses and CC in one send.
- OpenAPI spec updated.
- Logs the recipient **count** instead of the addresses (fixes CodeQL log-injection and avoids logging recipient e-mail addresses / personal data).

### Backward compatibility
Existing calls using only `emailAddress` work unchanged (regression test kept). The old singular attribute is removed in a future major.

### Test
`mvn verify` green: 57 unit + 3 integration tests (incl. AppTest delivering multiple To + CC via Mailpit), JaCoCo 85/85, OpenAPI contract test.

Part of the multi-recipient work: EmailSender (2647) → Messaging (2648) → SupportManagement (2650) + CaseData (2649).